### PR TITLE
fix csproj requirements

### DIFF
--- a/Soundboard4MacroDeck.csproj
+++ b/Soundboard4MacroDeck.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionMajor>2</VersionMajor>
-    <VersionMinor>4</VersionMinor>
-    <VersionPatch>0</VersionPatch>
     <VersionRevision Condition="'$(VersionRevision)' == ''">$([System.DateTime]::UtcNow.ToString("yy"))$([System.DateTime]::UtcNow.DayOfYear.ToString("000"))</VersionRevision>
-    <!--<PluginFolder>E:\Code\source\repos\MD\Macro-Deck\MacroDeck\bin\Debug\net7.0-windows10.0.22000.0\win-x64\Data\plugins</PluginFolder>-->
-    <!--<PluginFolder>$(AppData)\Macro Deck\plugins</PluginFolder>-->
   </PropertyGroup>
+	
   <PropertyGroup>
+    <Version>2.4.0</Version>
+    <AssemblyVersion>2.$(VersionRevision)</AssemblyVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <TargetFramework>net10.0-windows10.0.22000.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Soundboard4MacroDeck</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <UseWindowsForms>true</UseWindowsForms>
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
     <AssemblyName>Soundboard4MacroDeck</AssemblyName>
@@ -21,8 +21,6 @@
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>PhoenixWyllow</Authors>
     <Copyright>PhoenixWyllow aka PW.Dev (pw.dev@outlook.com)</Copyright>
-    <AssemblyVersion>$(VersionMajor).$(VersionMinor).$(VersionRevision)</AssemblyVersion>
-    <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch)</Version>
     <OutputType>Library</OutputType>
     <StartupObject />
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -32,21 +30,23 @@
     <Description>A soundboard plugin for Macro Deck 2</Description>
     <PackageProjectUrl>https://github.com/PhoenixWyllow/Soundboard4MacroDeck2/releases</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PhoenixWyllow/Soundboard4MacroDeck2</RepositoryUrl>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+	
   <ItemGroup>
     <None Remove="Resources\Languages\*.json" />
   </ItemGroup>
+	
   <ItemGroup>
     <EmbeddedResource Include="Resources\Languages\*.json" />
   </ItemGroup>
+	
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.3.0" />
     <PackageReference Include="NAudio.Extras" Version="2.3.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.11.285" />
     <PackageReference Include="SuchByte.MacroDeck" Version="2.15.0" />
   </ItemGroup>
+	
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -54,12 +54,14 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
+	
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+	
   <ItemGroup>
     <None Update="ExtensionIcon.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -74,11 +76,17 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+	
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <ItemGroup>
       <PluginFiles Include="$(OutDir)\Soundboard4MacroDeck.dll;$(OutDir)\NAudio*.dll;$(OutDir)\ExtensionManifest.json;$(OutDir)\ExtensionIcon.png" />
     </ItemGroup>
     <RemoveDir Directories="$(ProjectDir)releases\$(Configuration)\PhoenixWyllow.$(TargetName)\" />
-    <Copy DestinationFolder="$(ProjectDir)releases\$(Configuration)\PhoenixWyllow.$(TargetName)\" SourceFiles="@(PluginFiles)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" />
+    <Copy 
+		DestinationFolder="$(ProjectDir)releases\$(Configuration)\PhoenixWyllow.$(TargetName)\"
+		SourceFiles="@(PluginFiles)"
+		OverwriteReadOnlyFiles="true"
+		SkipUnchangedFiles="true"
+		/>
   </Target>
 </Project>


### PR DESCRIPTION
This pull request updates the project file for `Soundboard4MacroDeck`.

**Versioning and Assembly Information:**
* Replaced individual major/minor/patch version properties with a single `Version` property (`2.4.0`) and updated `AssemblyVersion` to use the revision for more consistent versioning. [[1]](diffhunk://#diff-485e8ee7b449e87db82041a8386d457aaac29ab55a37d16a13dd643d07578c71L3-R15) [[2]](diffhunk://#diff-485e8ee7b449e87db82041a8386d457aaac29ab55a37d16a13dd643d07578c71L24-L25)

**Project File Organization:**
* Cleaned up and reorganized `PropertyGroup` and `ItemGroup` sections for better clarity and maintainability.