### PR TITLE
fix: Make Node.Children and Extensions nullable

### DIFF
--- a/ExtensionManifest.json
+++ b/ExtensionManifest.json
@@ -4,7 +4,7 @@
   "author": "PhoenixWyllow",
   "repository": "https://github.com/PhoenixWyllow/Soundboard4MacroDeck2",
   "packageId": "PhoenixWyllow.Soundboard4MacroDeck",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "target-plugin-api-version": 41,
   "target-macro-deck-version": "2.15.0",
   "dll": "Soundboard4MacroDeck.dll"

--- a/MimeSniffer/Node.cs
+++ b/MimeSniffer/Node.cs
@@ -8,7 +8,7 @@ public class Node
     /// <summary>
     /// Gets or sets children.
     /// </summary>
-    public SortedList<byte, Node> Children { get; set; } = new();
+    public SortedList<byte, Node>? Children { get; set; }
 
     /// <summary>
     /// Gets or sets depth.
@@ -18,7 +18,7 @@ public class Node
     /// <summary>
     /// Gets or sets extentions.
     /// </summary>
-    public List<string> Extensions { get; set; } = new();
+    public List<string>? Extensions { get; set; }
 
     /// <summary>
     /// Gets or sets parent node.

--- a/MimeSniffer/Sniffer.cs
+++ b/MimeSniffer/Sniffer.cs
@@ -125,7 +125,8 @@ public class Sniffer
             return;
         }
 
-        node.Children.TryGetValue(data[depth], out Node? current);
+        Node? current = null;
+        node.Children?.TryGetValue(data[depth], out current);
 
         // can't find matched node, match ended.
         if (current is null)

--- a/Soundboard4MacroDeck.csproj
+++ b/Soundboard4MacroDeck.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 	
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <AssemblyVersion>2.$(VersionRevision)</AssemblyVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <TargetFramework>net10.0-windows10.0.22000.0</TargetFramework>


### PR DESCRIPTION
- Changed Node.Children and Extensions to nullable types without default instances. 
- Updated Sniffer.cs to use null-conditional access for Children.

resolves #82 